### PR TITLE
Update for supporting Rollup v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "chalk": "^1.1.3",
-    "rollup-pluginutils": "^1.5.1"
+    "chalk": "^1.1.3"
   },
   "devDependencies": {
     "rollup": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-pluginutils": "^1.5.1"
   },
   "devDependencies": {
-    "rollup": "^0.36.0",
-    "rollup-plugin-buble": "^0.14.0"
+    "rollup": "^1.0.0",
+    "rollup-plugin-buble": "^0.19.6"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,11 @@ import buble from 'rollup-plugin-buble';
 const external = Object.keys(require('./package.json').dependencies).concat(['fs', 'path', 'readline']);
 
 export default {
-  entry: 'src/index.js',
+  input: 'src/index.js',
   plugins: [ buble() ],
   external: external,
-  targets: [
-    { dest: 'dist/rollup-plugin-progress.js', format: 'cjs' },
-    { dest: 'dist/rollup-plugin-progress.esm.js', format: 'es' }
+  output: [
+    { file: 'dist/rollup-plugin-progress.js', format: 'cjs' },
+    { file: 'dist/rollup-plugin-progress.esm.js', format: 'es' }
   ]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import readline from 'readline';
-import { createFilter } from 'rollup-pluginutils';
 
 function normalizePath(id) {
   return path.relative(process.cwd(), id).split(path.sep).join('/');
@@ -13,7 +11,6 @@ export default function progress(options = {}) {
     options.clearLine = true;
   }
 
-  const filter = createFilter(options.include, options.exclude);
   let total = 0;
   const totalFilePath = path.resolve(__dirname, "./total.txt");
   try {
@@ -21,15 +18,14 @@ export default function progress(options = {}) {
   } catch (e) {
     fs.writeFileSync(totalFilePath, 0);
   }
-  let progress = {
+  const progress = {
     total: total,
     loaded: 0
   };
 
   return {
     name: 'progress',
-    load(id) {
-      const file = normalizePath(id);
+    load() {
       progress.loaded += 1;
     },
     transform(code, id) {

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export default function progress(options = {}) {
         console.log(`(${chalk.red(progress.loaded)}): ${file}`);
       }
     },
-    ongenerate() {
+    generateBundle() {
       fs.writeFileSync(totalFilePath, progress.loaded);
       if (options.clearLine && process.stdin.isTTY) {
         process.stdout.clearLine();


### PR DESCRIPTION
I replaced deprecated `ongenerate` hook with `generateBundle` hook to resolve #11.