### PR TITLE
fix: Changed isTTY check to use stdout.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export default function progress(options = {}) {
         return;
       }
 
-      if (options.clearLine && process.stdin.isTTY) {
+      if (options.clearLine && process.stdout.isTTY) {
         process.stdout.clearLine();
         process.stdout.cursorTo(0);
         let output = "";
@@ -54,7 +54,7 @@ export default function progress(options = {}) {
     },
     generateBundle() {
       fs.writeFileSync(totalFilePath, progress.loaded);
-      if (options.clearLine && process.stdin.isTTY) {
+      if (options.clearLine && process.stdout.isTTY) {
         process.stdout.clearLine();
         process.stdout.cursorTo(0);
       }


### PR DESCRIPTION
If a user attempts to redirect the output of rollup, when using this plugin, to something other than a TTY an error will throw: `TypeError: process.stdout.clearLine is not a function`

If the logic is changed to check if `stdout` is a TTY then this error will not be thrown.