### PR TITLE
Fix an error caused by node 14

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default function progress(options = {}) {
       }
     },
     generateBundle() {
-      fs.writeFileSync(totalFilePath, progress.loaded);
+      fs.writeFileSync(totalFilePath, String(progress.loaded));
       if (options.clearLine && process.stdout.isTTY) {
         process.stdout.clearLine();
         process.stdout.cursorTo(0);

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default function progress(options = {}) {
   try {
     total = fs.readFileSync(totalFilePath);
   } catch (e) {
-    fs.writeFileSync(totalFilePath, 0);
+    fs.writeFileSync(totalFilePath, "0");
   }
   const progress = {
     total: total,


### PR DESCRIPTION
In node 14, number is not a valid data type of fs.writeFileSync.
![image](https://user-images.githubusercontent.com/14858674/80376263-26918b80-88cc-11ea-8622-d41ec50186ea.png)

Close #17 